### PR TITLE
Handle string data in zip bundle stream

### DIFF
--- a/packages/zipper/lib/zip-bundle/index.ts
+++ b/packages/zipper/lib/zip-bundle/index.ts
@@ -32,7 +32,11 @@ function streamFileToZip(
   zip.add(data);
 
   createReadStream(absPath)
-    .on('data', (chunk: Buffer) => data.push(chunk, false))
+    .on('data', (chunk: string | Buffer) => {
+      // If the chunk is a string, convert it to a Buffer
+      const bufferChunk = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+      data.push(bufferChunk, false);
+    })
     .on('end', () => data.push(new Uint8Array(0), true))
     .on('error', error => {
       onAbort();


### PR DESCRIPTION
- Updated the 'data' event handler in the `streamFileToZip` function to handle string chunks. If the chunk is a string, it is now converted to a Buffer before being pushed to the data stream. This ensures that the function can handle both Buffer and string data types.

### pnpm run error
<img width="1068" alt="Screenshot 2025-03-08 at 13 11 04" src="https://github.com/user-attachments/assets/bc12856d-6cf9-4af0-9e5a-c11b2a4adca8" />

### Typescript error
<img width="750" alt="Screenshot 2025-03-08 at 13 10 37" src="https://github.com/user-attachments/assets/47a4a09b-0236-4700-a18b-07c41b5e7e88" />

