### PR TITLE
feat: Add OpenRouter provider support

### DIFF
--- a/chrome-extension/src/background/agent/agents/planner.ts
+++ b/chrome-extension/src/background/agent/agents/planner.ts
@@ -12,10 +12,24 @@ const logger = createLogger('PlannerAgent');
 export const plannerOutputSchema = z.object({
   observation: z.string(),
   challenges: z.string(),
-  done: z.boolean(),
+  done: z.union([
+    z.boolean(),
+    z.string().transform(val => {
+      if (val.toLowerCase() === 'true') return true;
+      if (val.toLowerCase() === 'false') return false;
+      throw new Error('Invalid boolean string');
+    }),
+  ]),
   next_steps: z.string(),
   reasoning: z.string(),
-  web_task: z.boolean(),
+  web_task: z.union([
+    z.boolean(),
+    z.string().transform(val => {
+      if (val.toLowerCase() === 'true') return true;
+      if (val.toLowerCase() === 'false') return false;
+      throw new Error('Invalid boolean string');
+    }),
+  ]),
 });
 
 export type PlannerOutput = z.infer<typeof plannerOutputSchema>;

--- a/chrome-extension/src/background/agent/agents/validator.ts
+++ b/chrome-extension/src/background/agent/agents/validator.ts
@@ -10,7 +10,14 @@ const logger = createLogger('ValidatorAgent');
 
 // Define Zod schema for validator output
 export const validatorOutputSchema = z.object({
-  is_valid: z.boolean(), // indicates if the output is correct
+  is_valid: z.union([
+    z.boolean(),
+    z.string().transform(val => {
+      if (val.toLowerCase() === 'true') return true;
+      if (val.toLowerCase() === 'false') return false;
+      throw new Error('Invalid boolean string');
+    }),
+  ]), // indicates if the output is correct
   reason: z.string(), // explains why it is valid or not
   answer: z.string(), // the final answer to the task if it is valid
 });

--- a/chrome-extension/src/background/agent/helper.ts
+++ b/chrome-extension/src/background/agent/helper.ts
@@ -43,6 +43,36 @@ export function createChatModel(
       }
       return new ChatOpenAI(args);
     }
+    case LLMProviderEnum.OpenRouter: {
+      if (agentName === AgentNameEnum.Planner) {
+        temperature = 0.02;
+      }
+      const args: any = {
+        model: modelName, // OpenRouter model ID (e.g., 'openai/gpt-4o')
+        apiKey: providerConfig.apiKey,
+        configuration: {
+          baseURL: providerConfig.baseUrl || 'https://openrouter.ai/api/v1',
+          defaultHeaders: {
+            'HTTP-Referer': 'https://nanobrowser.extension', // Required for OpenRouter
+            'X-Title': 'Nanobrowser Extension',
+          },
+        },
+      };
+
+      // Add parameters based on the model type
+      if (modelName.startsWith('openai/o')) {
+        // For OpenAI O-series models
+        args.modelKwargs = {
+          max_completion_tokens: maxCompletionTokens,
+        };
+      } else {
+        args.topP = topP;
+        args.temperature = temperature;
+        args.maxTokens = maxTokens;
+      }
+
+      return new ChatOpenAI(args);
+    }
     case LLMProviderEnum.Anthropic: {
       temperature = 0.1;
       topP = 0.1;

--- a/chrome-extension/src/background/agent/prompts/planner.ts
+++ b/chrome-extension/src/background/agent/prompts/planner.ts
@@ -35,11 +35,11 @@ RESPONSIBILITIES:
 RESPONSE FORMAT: Your must always respond with a valid JSON object with the following fields:
 {
     "observation": "Brief analysis of the current state and what has been done so far",
-    "done": "true or false, whether further steps are needed to complete the ultimate task",
+    "done": true or false, // Boolean value indicating whether further steps are needed to complete the ultimate task
     "challenges": "List any potential challenges or roadblocks",
     "next_steps": "List 2-3 high-level next steps to take, each step should start with a new line",
     "reasoning": "Explain your reasoning for the suggested next steps",
-    "web_task": "true or false, whether the ultimate task is related to browsing the web"
+    "web_task": true or false // Boolean value indicating whether the ultimate task is related to browsing the web
 }
 
 NOTE:

--- a/chrome-extension/src/background/agent/prompts/validator.ts
+++ b/chrome-extension/src/background/agent/prompts/validator.ts
@@ -60,9 +60,9 @@ SPECIAL CASES:
 
 RESPONSE FORMAT: You must ALWAYS respond with valid JSON in this exact format:
 {
-  "is_valid": boolean,  // true if task is completed correctly
-  "reason": string      // clear explanation of validation result
-  "answer": string      // empty string if is_valid is false; human-readable final answer and should not be empty if is_valid is true
+  "is_valid": true or false,  // Boolean value (not a string) indicating if task is completed correctly
+  "reason": string,           // clear explanation of validation result
+  "answer": string            // empty string if is_valid is false; human-readable final answer and should not be empty if is_valid is true
 }
 
 ANSWER FORMATTING GUIDELINES:

--- a/packages/storage/lib/settings/types.ts
+++ b/packages/storage/lib/settings/types.ts
@@ -9,9 +9,10 @@ export enum LLMProviderEnum {
   OpenAI = 'openai',
   Anthropic = 'anthropic',
   Gemini = 'gemini',
+  OpenRouter = 'openrouter',
 }
 
-export const llmProviderModelNames = {
+export const llmProviderModelNames: Record<LLMProviderEnum, string[]> = {
   [LLMProviderEnum.OpenAI]: ['gpt-4o', 'gpt-4o-mini', 'o1', 'o1-mini', 'o3-mini'],
   [LLMProviderEnum.Anthropic]: ['claude-3-7-sonnet-latest', 'claude-3-5-haiku-latest'],
   [LLMProviderEnum.Gemini]: [
@@ -20,6 +21,7 @@ export const llmProviderModelNames = {
     'gemini-2.0-pro-exp-02-05',
     // 'gemini-2.0-flash-thinking-exp-01-21', // TODO: not support function calling for now
   ],
+  [LLMProviderEnum.OpenRouter]: [], // Will be populated dynamically from the API
 };
 
 /**


### PR DESCRIPTION
This commit adds OpenRouter as a provider to the Chrome extension with the following changes:

1. Added OpenRouter to LLMProviderEnum in types.ts
2. Added OpenRouter models to llmProviderModelNames with dynamic fetching from API
3. Added OpenRouter API interfaces and fetchOpenRouterModels function to llmProviderStore
4. Implemented OpenRouter support in createChatModel function with proper headers
5. Added UI section for OpenRouter in ModelSettings component
6. Fixed boolean validation issues in agent schemas to support string representations
7. Updated prompts to explicitly instruct models to return boolean values

These changes allow users to:
- Configure OpenRouter API key in settings
- Fetch available models from OpenRouter API
- Select OpenRouter models for different agents
- Use OpenRouter as an LLM provider with proper API configuration