### PR TITLE
Add Azure OpenAI as a connection option

### DIFF
--- a/chrome-extension/src/background/agent/helper.ts
+++ b/chrome-extension/src/background/agent/helper.ts
@@ -2,6 +2,7 @@ import { type ProviderConfig, LLMProviderEnum, AgentNameEnum } from '@extension/
 import { ChatOpenAI } from '@langchain/openai';
 import { ChatAnthropic } from '@langchain/anthropic';
 import { ChatGoogleGenerativeAI } from '@langchain/google-genai';
+import { ChatAzureOpenAI } from '@langchain/azure-openai';
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 
 // create a chat model based on the agent name, the model name and provider
@@ -71,6 +72,18 @@ export function createChatModel(
         topP,
       };
       return new ChatGoogleGenerativeAI(args);
+    }
+    case LLMProviderEnum.AzureOpenAI: {
+      temperature = 0.2;
+      topP = 0.9;
+      const args = {
+        model: modelName,
+        apiKey: providerConfig.apiKey,
+        baseUrl: providerConfig.baseUrl,
+        temperature,
+        topP,
+      };
+      return new ChatAzureOpenAI(args);
     }
     default: {
       throw new Error(`Provider ${providerName} not supported yet`);

--- a/chrome-extension/src/background/agent/types.ts
+++ b/chrome-extension/src/background/agent/types.ts
@@ -161,3 +161,10 @@ export interface AgentOutput<T = unknown> {
    */
   error?: string;
 }
+
+export enum LLMProviderEnum {
+  OpenAI = 'openai',
+  Anthropic = 'anthropic',
+  Gemini = 'gemini',
+  AzureOpenAI = 'azure-openai',
+}


### PR DESCRIPTION
Add support for Azure OpenAI as a connection option.

* **`chrome-extension/src/background/agent/helper.ts`**
  - Import `ChatAzureOpenAI` from `@langchain/azure-openai`.
  - Update `createChatModel` function to support Azure OpenAI by adding a case for `LLMProviderEnum.AzureOpenAI` and setting the `apiKey` and `baseUrl`.

* **`chrome-extension/src/background/agent/types.ts`**
  - Add `AzureOpenAI` to the `LLMProviderEnum`.

