### PR TITLE
doc: update JSDoc of utility function `getCurrentTimestampStr`

### DIFF
--- a/chrome-extension/src/background/utils.ts
+++ b/chrome-extension/src/background/utils.ts
@@ -1,6 +1,6 @@
 export function getCurrentTimestampStr(): string {
   /**
-   * Get the current timestamp as a string in the format yyyy-MM-dd HH:mm:ss
+   * Get the current timestamp as a string in the format yyyy/MM/dd HH:mm:ss
    * using local timezone.
    *
    * @returns Formatted datetime string in local time


### PR DESCRIPTION
The actual output format of the utility function `getCurrentTimestampStr` is `yyyy/MM/dd HH:mm:ss`.

In order not to modify the logic of the function, I chose to update the JSDoc.

![1742380937199](https://github.com/user-attachments/assets/fcede408-830d-4f34-a48e-5ca67c6248ba)
