### PR TITLE
feat: add `isComposing` check to function `handleKeyDown` in file `pages/side-panel/src/components/ChatInput.tsx`

### DIFF
--- a/pages/side-panel/src/components/ChatInput.tsx
+++ b/pages/side-panel/src/components/ChatInput.tsx
@@ -62,7 +62,7 @@ export default function ChatInput({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
+      if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
         e.preventDefault();
         handleSubmit(e);
       }


### PR DESCRIPTION
Why: Provide better UX for users with languages ​​that require an IME (Input Method Editor), such as Chinese, Japanese.

Before: 
(When I am choosing Chinese words with "enter", it triggers submit.)
[Click to watch video](https://drive.google.com/file/d/1aMZzihHXCZlAN10nfqcn8RzxwPL1pyEP/view?usp=drive_link)

After: 
(When I am choosing Chinese words with "enter", it does not trigger submit.)
[Click to watch video](https://drive.google.com/file/d/1P2weDo-Bcok_RlrEXHOYrVfe22bO8K0R/view?usp=drive_link)
