### PR TITLE
style: add `break-words` to prevent overflow

### DIFF
--- a/pages/options/src/components/ModelSettings.tsx
+++ b/pages/options/src/components/ModelSettings.tsx
@@ -918,7 +918,8 @@ export const ModelSettings = ({ isDarkMode = false }: ModelSettingsProps) => {
                     !providersFromStorage.has(providerId) &&
                     providerConfig.apiKey && (
                       <div className="ml-20 mt-1">
-                        <p className={`font-mono text-sm ${isDarkMode ? 'text-emerald-400' : 'text-emerald-600'}`}>
+                        <p
+                          className={`font-mono text-sm break-words ${isDarkMode ? 'text-emerald-400' : 'text-emerald-600'}`}>
                           {providerConfig.apiKey}
                         </p>
                       </div>


### PR DESCRIPTION
I accidentally found that in some random cases API Key could cause window overflow

P.S. The API Key had already been revoked, so it's okay to share the screenshot.
<img width="1600" alt="截圖 2025-03-28 上午10 54 44（2）" src="https://github.com/user-attachments/assets/2a8aaf80-e5cb-469e-a62c-0b00b4fb17f4" />

By the way, thank you for creating this project, it is a very creative idea:)
