### PR TITLE
feat: Add Mac keyboard mapping support

### DIFF
--- a/chrome-extension/src/background/browser/page.ts
+++ b/chrome-extension/src/background/browser/page.ts
@@ -462,6 +462,20 @@ export default class Page {
 
   private _convertKey(key: string): KeyInput {
     const lowerKey = key.trim().toLowerCase();
+    const isMac = navigator.userAgent.toLowerCase().includes('mac os x');
+
+    if (isMac) {
+      if (lowerKey === 'control' || lowerKey === 'ctrl') {
+        return 'Meta' as KeyInput; // Use Command key on Mac
+      }
+      if (lowerKey === 'command' || lowerKey === 'cmd') {
+        return 'Meta' as KeyInput; // Map Command/Cmd to Meta on Mac
+      }
+      if (lowerKey === 'option' || lowerKey === 'opt') {
+        return 'Alt' as KeyInput; // Map Option/Opt to Alt on Mac
+      }
+    }
+
     const keyMap: { [key: string]: string } = {
       // Letters
       a: 'KeyA',


### PR DESCRIPTION
This PR adds keyboard mapping support for Mac OS users, specifically handling the following key mappings:

- Control/Ctrl key → Command (Meta) key
- Command/Cmd key → Command (Meta) key
- Option/Opt key → Alt key

This change ensures proper keyboard functionality when using the extension on Mac OS systems, where the keyboard layout differs from other operating systems.