### PR TITLE
Add Groq as a supported LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Looking for a powerful AI web agent without the $200/month price tag of OpenAI O
 - **Flexible LLM Options** - Connect to your preferred LLM providers with the freedom to choose different models for different agents.
 - **Fully Open Source** - Complete transparency in how your browser is automated. No black boxes or hidden processes.
 
-> **Note:** We currently support OpenAI, Anthropic, Gemini, Ollama and custom OpenAI-Compatible providers, more providers will be supported.
+> **Note:** We currently support OpenAI, Anthropic, Gemini, Ollama, Groq and custom OpenAI-Compatible providers, more providers will be supported.
 
 
 ## 📊 Key Features

--- a/chrome-extension/package.json
+++ b/chrome-extension/package.json
@@ -22,6 +22,7 @@
     "@langchain/core": "0.3.56",
     "@langchain/deepseek": "^0.0.1",
     "@langchain/google-genai": "0.2.9",
+    "@langchain/groq": "^0.2.2",
     "@langchain/ollama": "^0.2.0",
     "@langchain/openai": "0.5.10",
     "@langchain/xai": "^0.0.2",

--- a/chrome-extension/src/background/agent/helper.ts
+++ b/chrome-extension/src/background/agent/helper.ts
@@ -3,6 +3,7 @@ import { ChatOpenAI, AzureChatOpenAI } from '@langchain/openai';
 import { ChatAnthropic } from '@langchain/anthropic';
 import { ChatGoogleGenerativeAI } from '@langchain/google-genai';
 import { ChatXAI } from '@langchain/xai';
+import { ChatGroq } from '@langchain/groq';
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { ChatOllama } from '@langchain/ollama';
 import { ChatDeepSeek } from '@langchain/deepseek';
@@ -217,6 +218,16 @@ export function createChatModel(providerConfig: ProviderConfig, modelConfig: Mod
         configuration: {},
       };
       return new ChatXAI(args) as BaseChatModel;
+    }
+    case ProviderTypeEnum.Groq: {
+      const args = {
+        model: modelConfig.modelName,
+        apiKey: providerConfig.apiKey,
+        temperature,
+        topP,
+        maxTokens,
+      };
+      return new ChatGroq(args);
     }
     case ProviderTypeEnum.Ollama: {
       const args: {

--- a/packages/storage/lib/settings/llmProviders.ts
+++ b/packages/storage/lib/settings/llmProviders.ts
@@ -63,6 +63,7 @@ export function getProviderTypeByProviderId(providerId: string): ProviderTypeEnu
     case ProviderTypeEnum.Grok:
     case ProviderTypeEnum.Ollama:
     case ProviderTypeEnum.OpenRouter:
+    case ProviderTypeEnum.Groq:
       return providerId;
     default:
       return ProviderTypeEnum.CustomOpenAI;
@@ -89,6 +90,8 @@ export function getDefaultDisplayNameFromProviderId(providerId: string): string 
       return 'Azure OpenAI';
     case ProviderTypeEnum.OpenRouter:
       return 'OpenRouter';
+    case ProviderTypeEnum.Groq:
+      return 'Groq';
     default:
       return providerId; // Use the provider id as display name for custom providers by default
   }
@@ -103,6 +106,7 @@ export function getDefaultProviderConfig(providerId: string): ProviderConfig {
     case ProviderTypeEnum.Gemini:
     case ProviderTypeEnum.Grok:
     case ProviderTypeEnum.OpenRouter: // OpenRouter uses modelNames
+    case ProviderTypeEnum.Groq: // Groq uses modelNames
       return {
         apiKey: '',
         name: getDefaultDisplayNameFromProviderId(providerId),

--- a/packages/storage/lib/settings/types.ts
+++ b/packages/storage/lib/settings/types.ts
@@ -17,6 +17,7 @@ export enum ProviderTypeEnum {
   Ollama = 'ollama',
   AzureOpenAI = 'azure_openai',
   OpenRouter = 'openrouter',
+  Groq = 'groq',
   CustomOpenAI = 'custom_openai',
 }
 
@@ -40,6 +41,11 @@ export const llmProviderModelNames = {
     'openai/o4-mini',
     'openai/gpt-4o-2024-11-20',
     'google/gemini-2.5-flash-preview',
+  ],
+  [ProviderTypeEnum.Groq]: [
+    'llama-3.3-70b-versatile',
+    'meta-llama/llama-4-scout-17b-16e-instruct',
+    'meta-llama/llama-4-maverick-17b-128e-instruct',
   ],
   // Custom OpenAI providers don't have predefined models as they are user-defined
 };
@@ -131,6 +137,20 @@ export const llmProviderParameters = {
     },
   },
   [ProviderTypeEnum.OpenRouter]: {
+    [AgentNameEnum.Planner]: {
+      temperature: 0.7,
+      topP: 0.9,
+    },
+    [AgentNameEnum.Navigator]: {
+      temperature: 0.3,
+      topP: 0.85,
+    },
+    [AgentNameEnum.Validator]: {
+      temperature: 0.1,
+      topP: 0.8,
+    },
+  },
+  [ProviderTypeEnum.Groq]: {
     [AgentNameEnum.Planner]: {
       temperature: 0.7,
       topP: 0.9,

--- a/pages/options/src/components/ModelSettings.tsx
+++ b/pages/options/src/components/ModelSettings.tsx
@@ -394,6 +394,7 @@ export const ModelSettings = ({ isDarkMode = false }: ModelSettingsProps) => {
       }
 
       // Check if base URL is required but missing for custom_openai, ollama, azure_openai or openrouter
+      // Note: Groq does not require base URL as it uses the default endpoint
       if (
         (providers[provider].type === ProviderTypeEnum.CustomOpenAI ||
           providers[provider].type === ProviderTypeEnum.Ollama ||

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       '@langchain/google-genai':
         specifier: 0.2.9
         version: 0.2.9(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.24.4)))(zod@3.24.4)
+      '@langchain/groq':
+        specifier: ^0.2.2
+        version: 0.2.2(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.24.4)))
       '@langchain/ollama':
         specifier: ^0.2.0
         version: 0.2.0(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.24.4)))
@@ -631,6 +634,12 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@langchain/core': '>=0.3.55 <0.4.0'
+
+  '@langchain/groq@0.2.2':
+    resolution: {integrity: sha512-kvLhDrNimamQBXlP4LFb/x9Y3tuObHhgmbC3ponLGWgL/Vu6q+UGOAUCJIC0DnOUTYXpgklHRgQKw484HJx+mw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': '>=0.2.21 <0.4.0'
 
   '@langchain/ollama@0.2.0':
     resolution: {integrity: sha512-jLlYFqt+nbhaJKLakk7lRTWHZJ7wHeJLM6yuv4jToQ8zPzpL//372+MjggDoW0mnw8ofysg1T2C6mEJspKJtiA==}
@@ -2017,6 +2026,9 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  groq-sdk@0.19.0:
+    resolution: {integrity: sha512-vdh5h7ORvwvOvutA80dKF81b0gPWHxu6K/GOJBOM0n6p6CSqAVLhFfeS79Ef0j/yCycDR09jqY7jkYz9dLiS6w==}
 
   has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
@@ -3676,6 +3688,15 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  '@langchain/groq@0.2.2(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.24.4)))':
+    dependencies:
+      '@langchain/core': 0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.24.4))
+      groq-sdk: 0.19.0
+      zod: 3.24.4
+      zod-to-json-schema: 3.24.5(zod@3.24.4)
+    transitivePeerDependencies:
+      - encoding
+
   '@langchain/ollama@0.2.0(@langchain/core@0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.24.4)))':
     dependencies:
       '@langchain/core': 0.3.56(openai@4.100.0(ws@8.18.2)(zod@3.24.4))
@@ -5219,6 +5240,18 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
+
+  groq-sdk@0.19.0:
+    dependencies:
+      '@types/node': 18.19.74
+      '@types/node-fetch': 2.6.12
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   has-bigints@1.0.2: {}
 


### PR DESCRIPTION
This PR adds support for using Groq as an LLM provider within the extension.

- Users can now configure their Groq API keys in the settings
- Added Groq models including Llama 3, Llama 4, etc.
- The underlying code for managing provider configurations and creating chat models has been updated to handle Groq

Fixes #120