### PR TITLE
fix: remove invalid sidebar_action from Chrome manifest - Fix Manifes…

### DIFF
--- a/chrome-extension/manifest.js
+++ b/chrome-extension/manifest.js
@@ -31,8 +31,8 @@ function withSidePanel(manifest) {
  * This is compatible with Chrome extensions and won't break Chrome Web Store validation.
  */
 function withOperaSidebar(manifest) {
-  // Only add Opera sidebar_action if not Firefox (Opera is Chromium-based)
-  if (isFirefox) {
+  // Only add Opera sidebar_action if building specifically for Opera
+  if (isFirefox || !isOpera) {
     return manifest;
   }
 


### PR DESCRIPTION
## Problem
Chrome Extension Manifest V3 validation was failing due to an unrecognized `sidebar_action` key, which is not supported in Chrome extensions.

## Solution
- Modified `withOperaSidebar` function to only include `sidebar_action` when building specifically for Opera
- Preserved `side_panel` functionality for Chrome using the correct API
- Fixed manifest validation errors during Chrome extension installation

## Changes
- Updated condition in `chrome-extension/manifest.js` to prevent `sidebar_action` from being added to Chrome builds
- No functionality lost - side panel continues to work correctly in Chrome

## Testing
- ✅ Extension builds successfully without manifest errors
- ✅ Generated `manifest.json` only contains valid keys
- ✅ Side panel functionality preserved

Fixes the manifest validation error reported in the build process.