### PR TITLE
fix: resolve model name collision between providers by storing provider>model pairs

### DIFF
--- a/pages/options/src/components/ModelSettings.tsx
+++ b/pages/options/src/components/ModelSettings.tsx
@@ -107,7 +107,8 @@ export const ModelSettings = ({ isDarkMode = false }: ModelSettingsProps) => {
         for (const agent of Object.values(AgentNameEnum)) {
           const config = await agentModelStore.getAgentModel(agent);
           if (config) {
-            models[agent] = config.modelName;
+            // Store in provider>model format
+            models[agent] = `${config.provider}>${config.modelName}`;
             if (config.parameters?.temperature !== undefined || config.parameters?.topP !== undefined) {
               setModelParameters(prev => ({
                 ...prev,
@@ -546,9 +547,10 @@ export const ModelSettings = ({ isDarkMode = false }: ModelSettingsProps) => {
       [agentName]: newParameters,
     }));
 
+    // Store both provider and model name in the format "provider>model"
     setSelectedModels(prev => ({
       ...prev,
-      [agentName]: model,
+      [agentName]: modelValue,  // Store the full provider>model value
     }));
 
     try {
@@ -710,11 +712,7 @@ export const ModelSettings = ({ isDarkMode = false }: ModelSettingsProps) => {
             id={`${agentName}-model`}
             className={`flex-1 rounded-md border text-sm ${isDarkMode ? 'border-slate-600 bg-slate-700 text-gray-200' : 'border-gray-300 bg-white text-gray-700'} px-3 py-2`}
             disabled={availableModels.length === 0}
-            value={
-              selectedModels[agentName]
-                ? `${getProviderForModel(selectedModels[agentName])}>${selectedModels[agentName]}`
-                : ''
-            }
+            value={selectedModels[agentName] || ''}  // Use the stored provider>model value directly
             onChange={e => handleModelChange(agentName, e.target.value)}>
             <option key="default" value="">
               Choose model


### PR DESCRIPTION
## Bug Fix: Model Selection Override Issue

### What Bug Was Fixed
When multiple providers had models with the same name (e.g., both Groq and Cerebras having Llama models), selecting a model from the second provider would incorrectly use the first provider's model. This happened because the model selection was only storing the model name without its provider context.

### How It Was Fixed
- Modified the model selection to store both provider and model name in a `provider>model` format
- Updated the UI to use this combined value directly instead of trying to reconstruct it
- Ensured consistent storage and retrieval of the provider-model relationship

### Additional Context
- This fix maintains backward compatibility with existing stored configurations
- No changes to the database schema were needed
- The fix is minimal and focused on the state management layer
- Tested with multiple providers having models with the same name (Groq/Cerebras Llama models)

### Testing
1. Set up both Groq and Cerebras providers
2. Select a Llama model from Groq
3. Select a Llama model from Cerebras
4. Verify each selection maintains its correct provider association