### PR TITLE
Feature: Fetch instructions from remote server

### DIFF
--- a/chrome-extension/manifest.js
+++ b/chrome-extension/manifest.js
@@ -49,52 +49,60 @@ function withOperaSidebar(manifest) {
  * After changing, please reload the extension at `chrome://extensions`
  * @type {chrome.runtime.ManifestV3}
  */
-const manifest = withOperaSidebar(
-  withSidePanel({
-    manifest_version: 3,
-    default_locale: 'en',
-    /**
-     * if you want to support multiple languages, you can use the following reference
-     * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Internationalization
-     */
-    name: '__MSG_extensionName__',
-    version: packageJson.version,
-    description: '__MSG_extensionDescription__',
-    host_permissions: ['<all_urls>'],
-    permissions: ['storage', 'scripting', 'tabs', 'activeTab', 'debugger', 'unlimitedStorage', 'webNavigation'],
-    options_page: 'options/index.html',
-    background: {
-      service_worker: 'background.iife.js',
-      type: 'module',
+const manifest = withOperaSidebar({
+  manifest_version: 3,
+  default_locale: 'en',
+  /**
+   * if you want to support multiple languages, you can use the following reference
+   * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Internationalization
+   */
+  name: '__MSG_extensionName__',
+  version: packageJson.version,
+  description: '__MSG_extensionDescription__',
+  host_permissions: ['<all_urls>', 'http://localhost:3000/*'],
+  permissions: [
+    'storage',
+    'scripting',
+    'tabs',
+    'activeTab',
+    'debugger',
+    'unlimitedStorage',
+    'webNavigation',
+    // 'sidePanel', // Permission for side panel is not needed anymore
+  ],
+  options_page: 'options/index.html',
+  background: {
+    service_worker: 'background.iife.js',
+    type: 'module',
+  },
+  action: {
+    default_icon: 'icon-32.png',
+  },
+  icons: {
+    128: 'icon-128.png',
+  },
+  content_scripts: [
+    {
+      matches: ['http://*/*', 'https://*/*', '<all_urls>'],
+      all_frames: true,
+      js: ['content/index.iife.js'],
     },
-    action: {
-      default_icon: 'icon-32.png',
+  ],
+  web_accessible_resources: [
+    {
+      resources: [
+        '*.js',
+        '*.css',
+        '*.svg',
+        'icon-128.png',
+        'icon-32.png',
+        'permission/index.html',
+        'permission/permission.js',
+        'config.json', // Add config.json to web accessible resources
+      ],
+      matches: ['*://*/*'],
     },
-    icons: {
-      128: 'icon-128.png',
-    },
-    content_scripts: [
-      {
-        matches: ['http://*/*', 'https://*/*', '<all_urls>'],
-        all_frames: true,
-        js: ['content/index.iife.js'],
-      },
-    ],
-    web_accessible_resources: [
-      {
-        resources: [
-          '*.js',
-          '*.css',
-          '*.svg',
-          'icon-128.png',
-          'icon-32.png',
-          'permission/index.html',
-          'permission/permission.js',
-        ],
-        matches: ['*://*/*'],
-      },
-    ],
-  }),
-);
+  ],
+});
 
 export default manifest;

--- a/chrome-extension/public/config.json
+++ b/chrome-extension/public/config.json
@@ -1,0 +1,4 @@
+{
+  "serverUrl": "http://localhost:3000/nano_instructions.json",
+  "pollingInterval": 5000
+}

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -20,10 +20,67 @@ const logger = createLogger('background');
 
 const browserContext = new BrowserContext({});
 let currentExecutor: Executor | null = null;
-let currentPort: chrome.runtime.Port | null = null;
+let lastInstruction: string | null = null;
+let pollingIntervalId: number | null = null;
 
-// Setup side panel behavior
-chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true }).catch(error => console.error(error));
+// This is the new polling logic to fetch instructions from a remote server.
+const pollInstructions = async () => {
+  try {
+    // Fetch the configuration
+    const configResponse = await fetch(chrome.runtime.getURL('config.json'));
+    const config = await configResponse.json();
+    const { serverUrl, pollingInterval } = config;
+
+    // If the polling interval has changed, we need to clear the old interval and set a new one.
+    if (pollingIntervalId) {
+      clearInterval(pollingIntervalId);
+    }
+    pollingIntervalId = window.setInterval(pollInstructions, pollingInterval);
+
+
+    // Fetch the instructions from the server
+    const response = await fetch(serverUrl);
+    // get the text and remove quotes
+    const instruction = (await response.text()).replace(/"/g, '');
+
+
+    // If the instruction is new and not empty, execute it.
+    if (instruction && instruction !== lastInstruction) {
+      lastInstruction = instruction;
+
+      // Get the current active tab
+      const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+      if (tabs.length === 0) {
+        logger.error('No active tab found to execute the instruction.');
+        return;
+      }
+      const tabId = tabs[0].id;
+      if (!tabId) {
+        logger.error('Active tab has no ID.');
+        return;
+      }
+
+      // The task ID can be a simple timestamp for now.
+      const taskId = Date.now().toString();
+
+      logger.info('New instruction received:', instruction);
+      currentExecutor = await setupExecutor(taskId, instruction, browserContext);
+      subscribeToExecutorEvents(currentExecutor);
+
+      // We need to switch to the tab before executing the task.
+      await browserContext.switchTab(tabId);
+
+      const result = await currentExecutor.execute();
+      logger.info('Instruction execution result:', result);
+    }
+  } catch (error) {
+    logger.error('Error polling for instructions:', error);
+  }
+};
+
+// Start polling for instructions when the extension is loaded.
+pollInstructions();
+
 
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
   if (tabId && changeInfo.status === 'complete' && tab.url?.startsWith('http')) {
@@ -57,188 +114,7 @@ chrome.runtime.onMessage.addListener(() => {
   // return false;
 });
 
-// Setup connection listener for long-lived connections (e.g., side panel)
-chrome.runtime.onConnect.addListener(port => {
-  if (port.name === 'side-panel-connection') {
-    currentPort = port;
-
-    port.onMessage.addListener(async message => {
-      try {
-        switch (message.type) {
-          case 'heartbeat':
-            // Acknowledge heartbeat
-            port.postMessage({ type: 'heartbeat_ack' });
-            break;
-
-          case 'new_task': {
-            if (!message.task) return port.postMessage({ type: 'error', error: 'No task provided' });
-            if (!message.tabId) return port.postMessage({ type: 'error', error: 'No tab ID provided' });
-
-            logger.info('new_task', message.tabId, message.task);
-            currentExecutor = await setupExecutor(message.taskId, message.task, browserContext);
-            subscribeToExecutorEvents(currentExecutor);
-
-            const result = await currentExecutor.execute();
-            logger.info('new_task execution result', message.tabId, result);
-            break;
-          }
-
-          case 'follow_up_task': {
-            if (!message.task) return port.postMessage({ type: 'error', error: 'No follow up task provided' });
-            if (!message.tabId) return port.postMessage({ type: 'error', error: 'No tab ID provided' });
-
-            logger.info('follow_up_task', message.tabId, message.task);
-
-            // If executor exists, add follow-up task
-            if (currentExecutor) {
-              currentExecutor.addFollowUpTask(message.task);
-              // Re-subscribe to events in case the previous subscription was cleaned up
-              subscribeToExecutorEvents(currentExecutor);
-              const result = await currentExecutor.execute();
-              logger.info('follow_up_task execution result', message.tabId, result);
-            } else {
-              // executor was cleaned up, can not add follow-up task
-              logger.info('follow_up_task: executor was cleaned up, can not add follow-up task');
-              return port.postMessage({ type: 'error', error: 'Executor was cleaned up, can not add follow-up task' });
-            }
-            break;
-          }
-
-          case 'cancel_task': {
-            if (!currentExecutor) return port.postMessage({ type: 'error', error: 'No task to cancel' });
-            await currentExecutor.cancel();
-            break;
-          }
-
-          case 'resume_task': {
-            if (!currentExecutor) return port.postMessage({ type: 'error', error: 'No task to resume' });
-            await currentExecutor.resume();
-            return port.postMessage({ type: 'success' });
-          }
-
-          case 'pause_task': {
-            if (!currentExecutor) return port.postMessage({ type: 'error', error: 'No task to pause' });
-            await currentExecutor.pause();
-            return port.postMessage({ type: 'success' });
-          }
-
-          case 'screenshot': {
-            if (!message.tabId) return port.postMessage({ type: 'error', error: 'No tab ID provided' });
-            const page = await browserContext.switchTab(message.tabId);
-            const screenshot = await page.takeScreenshot();
-            logger.info('screenshot', message.tabId, screenshot);
-            return port.postMessage({ type: 'success', screenshot });
-          }
-
-          case 'state': {
-            try {
-              const browserState = await browserContext.getState(true);
-              const elementsText = browserState.elementTree.clickableElementsToString(
-                DEFAULT_AGENT_OPTIONS.includeAttributes,
-              );
-
-              logger.info('state', browserState);
-              logger.info('interactive elements', elementsText);
-              return port.postMessage({ type: 'success', msg: 'State printed to console' });
-            } catch (error) {
-              logger.error('Failed to get state:', error);
-              return port.postMessage({ type: 'error', error: 'Failed to get state' });
-            }
-          }
-
-          case 'nohighlight': {
-            const page = await browserContext.getCurrentPage();
-            await page.removeHighlight();
-            return port.postMessage({ type: 'success', msg: 'highlight removed' });
-          }
-
-          case 'speech_to_text': {
-            try {
-              if (!message.audio) {
-                return port.postMessage({
-                  type: 'speech_to_text_error',
-                  error: 'No audio data provided',
-                });
-              }
-
-              logger.info('Processing speech-to-text request...');
-
-              // Get all providers for speech-to-text service
-              const providers = await llmProviderStore.getAllProviders();
-
-              // Create speech-to-text service with all providers
-              const speechToTextService = await SpeechToTextService.create(providers);
-
-              // Extract base64 audio data (remove data URL prefix if present)
-              let base64Audio = message.audio;
-              if (base64Audio.startsWith('data:')) {
-                base64Audio = base64Audio.split(',')[1];
-              }
-
-              // Transcribe audio
-              const transcribedText = await speechToTextService.transcribeAudio(base64Audio);
-
-              logger.info('Speech-to-text completed successfully');
-              return port.postMessage({
-                type: 'speech_to_text_result',
-                text: transcribedText,
-              });
-            } catch (error) {
-              logger.error('Speech-to-text failed:', error);
-              return port.postMessage({
-                type: 'speech_to_text_error',
-                error: error instanceof Error ? error.message : 'Speech recognition failed',
-              });
-            }
-          }
-
-          case 'replay': {
-            if (!message.tabId) return port.postMessage({ type: 'error', error: 'No tab ID provided' });
-            if (!message.taskId) return port.postMessage({ type: 'error', error: 'No task ID provided' });
-            if (!message.historySessionId)
-              return port.postMessage({ type: 'error', error: 'No history session ID provided' });
-            logger.info('replay', message.tabId, message.taskId, message.historySessionId);
-
-            try {
-              // Switch to the specified tab
-              await browserContext.switchTab(message.tabId);
-              // Setup executor with the new taskId and a dummy task description
-              currentExecutor = await setupExecutor(message.taskId, message.task, browserContext);
-              subscribeToExecutorEvents(currentExecutor);
-
-              // Run replayHistory with the history session ID
-              const result = await currentExecutor.replayHistory(message.historySessionId);
-              logger.debug('replay execution result', message.tabId, result);
-            } catch (error) {
-              logger.error('Replay failed:', error);
-              return port.postMessage({
-                type: 'error',
-                error: error instanceof Error ? error.message : 'Replay failed',
-              });
-            }
-            break;
-          }
-
-          default:
-            return port.postMessage({ type: 'error', error: 'Unknown message type' });
-        }
-      } catch (error) {
-        console.error('Error handling port message:', error);
-        port.postMessage({
-          type: 'error',
-          error: error instanceof Error ? error.message : 'Unknown error',
-        });
-      }
-    });
-
-    port.onDisconnect.addListener(() => {
-      // this event is also triggered when the side panel is closed, so we need to cancel the task
-      console.log('Side panel disconnected');
-      currentPort = null;
-      currentExecutor?.cancel();
-    });
-  }
-});
+// The side panel connection logic has been removed, as instructions are now polled from a server.
 
 async function setupExecutor(taskId: string, task: string, browserContext: BrowserContext) {
   const providers = await llmProviderStore.getAllProviders();
@@ -315,20 +191,14 @@ async function setupExecutor(taskId: string, task: string, browserContext: Brows
   return executor;
 }
 
-// Update subscribeToExecutorEvents to use port
+// Update subscribeToExecutorEvents to log events to the console.
 async function subscribeToExecutorEvents(executor: Executor) {
   // Clear previous event listeners to prevent multiple subscriptions
   executor.clearExecutionEvents();
 
   // Subscribe to new events
   executor.subscribeExecutionEvents(async event => {
-    try {
-      if (currentPort) {
-        currentPort.postMessage(event);
-      }
-    } catch (error) {
-      logger.error('Failed to send message to side panel:', error);
-    }
+    logger.info('Executor event:', event);
 
     if (
       event.state === ExecutionState.TASK_OK ||


### PR DESCRIPTION
This change modifies the NanoBrowser Chrome extension to fetch automation instructions from a remote server instead of the local side panel.

Key changes:
- A `config.json` file has been added to `chrome-extension/public/` to allow for easy configuration of the server URL and polling interval.
- The side panel has been disabled by modifying `chrome-extension/manifest.js`. The `sidePanel` permission and related UI code have been removed.
- The background script (`chrome-extension/src/background/index.ts`) has been updated to:
  - Read the configuration from `config.json`.
  - Poll the specified server URL for instructions.
  - Execute the received instructions using the existing agent executor.
- The `manifest.js` has also been updated to make `config.json` web-accessible and to add host permissions for the default server URL.