### PR TITLE
fix: Handle Gemini models via OpenAI-compatible API endpoints

### DIFF
--- a/chrome-extension/src/background/agent/actions/schemas.ts
+++ b/chrome-extension/src/background/agent/actions/schemas.ts
@@ -108,7 +108,7 @@ export const cacheContentActionSchema: ActionSchema = {
   description: 'Cache what you have found so far from the current page for future use',
   schema: z.object({
     intent: z.string().default('').describe('purpose of this action'),
-    content: z.string().describe('content to cache'),
+    content: z.string().default('').describe('content to cache'),
   }),
 };
 

--- a/chrome-extension/src/background/agent/agents/navigator.ts
+++ b/chrome-extension/src/background/agent/agents/navigator.ts
@@ -112,8 +112,27 @@ export class NavigatorAgent extends BaseAgent<z.ZodType, NavigatorResult> {
         if (isAbortedError(error)) {
           throw error;
         }
-        const errorMessage = `Failed to invoke ${this.modelName} with structured output: \n${error instanceof Error ? error.message : String(error)}`;
-        throw new Error(errorMessage);
+
+        // Try to extract JSON from markdown code blocks if parsing failed
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        if (errorMessage.includes('is not valid JSON') && response?.raw?.content) {
+          try {
+            const content =
+              typeof response.raw.content === 'string' ? response.raw.content : JSON.stringify(response.raw.content);
+            // Remove markdown code blocks
+            const jsonMatch = content.match(/```(?:json)?\s*([\s\S]*?)```/);
+            if (jsonMatch) {
+              const extractedJson = JSON.parse(jsonMatch[1].trim());
+              const validated = this.modelOutputSchema.parse(extractedJson);
+              logger.info('Successfully extracted JSON from markdown code block');
+              return validated;
+            }
+          } catch (extractError) {
+            logger.error('Failed to extract JSON from markdown:', extractError);
+          }
+        }
+
+        throw new Error(`Failed to invoke ${this.modelName} with structured output: \n${errorMessage}`);
       }
 
       // Use type assertion to access the properties


### PR DESCRIPTION
## Summary

Fixes JSON parsing errors and schema validation issues when using Gemini models through OpenAI-compatible API endpoints.

**Related to #259** - This fix addresses issues encountered when testing Gemini models via OpenAI-compatible endpoints in the custom header/query/RAG functionality.

## Problem

When using Gemini models (e.g., `gemini-2.5-pro`) via OpenAI-compatible API endpoints, users encountered:

1. **JSON parsing errors**: `SyntaxError: Unexpected token '`', "```json..." is not valid JSON`
2. **Slow responses**: Double API calls (structured output fails → fallback succeeds)
3. **Schema validation errors**: Missing required fields in `cache_content.content`

## Solution

### 1. Model Detection & Optimization (base.ts)
- Detect Gemini models by name pattern (`gemini-*`)
- Skip structured output entirely for Gemini
- Use manual JSON extraction from the start
- **Result**: 2x faster (single API call instead of two)

### 2. Fallback Markdown Extraction (navigator.ts)
- Add safety net in catch block
- Extract JSON from markdown code blocks using regex
- Handles edge cases where ```json wrapping occurs

### 3. Schema Flexibility (schemas.ts)
- Make `cache_content.content` optional with default value
- Prevents validation errors when Gemini returns incomplete responses

## Changes

- `chrome-extension/src/background/agent/agents/base.ts` - Gemini detection & manual extraction
- `chrome-extension/src/background/agent/agents/navigator.ts` - Markdown extraction fallback
- `chrome-extension/src/background/agent/actions/schemas.ts` - Optional content field

## Testing

Tested with:
- ✅ Gemini 2.5 Pro via OpenAI-compatible endpoint
- ✅ JSON parsing now succeeds
- ✅ Single API call (2x faster)
- ✅ Schema validation passes

## Related

- #259 - Custom Header + Custom Query + RAG Functionality
- Applies the same pattern used for Llama models to Gemini models accessed via OpenAI-compatible endpoints.