### PR TITLE
feat: add optional custom baseUrl for all LLM providers & fix done action response display

### DIFF
--- a/packages/i18n/locales/en/messages.json
+++ b/packages/i18n/locales/en/messages.json
@@ -351,6 +351,9 @@
   "options_models_providers_baseUrl": {
     "message": "Base URL"
   },
+  "options_models_providers_useCustomBaseUrl": {
+    "message": "Use custom Base URL"
+  },
   "options_models_providers_endpoint": {
     "message": "Endpoint"
   },

--- a/packages/storage/lib/settings/types.ts
+++ b/packages/storage/lib/settings/types.ts
@@ -34,7 +34,7 @@ export const llmProviderModelNames = {
     'gpt-4.1-mini',
     'gpt-4o',
   ],
-  [ProviderTypeEnum.Anthropic]: ['claude-sonnet-4-5', 'claude-haiku-4-5', 'claude-opus-4-1'],
+  [ProviderTypeEnum.Anthropic]: ['claude-sonnet-4-5', 'claude-haiku-4-5', 'claude-opus-4-1', 'claude-opus-4-5'],
   [ProviderTypeEnum.DeepSeek]: ['deepseek-chat', 'deepseek-reasoner'],
   [ProviderTypeEnum.Gemini]: ['gemini-3-pro-preview', 'gemini-2.5-flash', 'gemini-2.5-pro'],
   [ProviderTypeEnum.Grok]: ['grok-4', 'grok-4-fast-non-reasoning', 'grok-3', 'grok-3-fast'],


### PR DESCRIPTION
## Summary

This PR includes two improvements:

1. **Optional Custom Base URL for All LLM Providers** - Allow users to configure custom API endpoints
2. **Fix Done Action Response Display** - Show Navigator's response text instead of just "done"

---

## Feature 1: Optional Custom Base URL for All Providers

### Problem
Users who want to use proxy servers or custom API endpoints (e.g., `http://proxy.example.com/v1/messages`) couldn't configure them for providers like Anthropic, Google, etc. Only the CustomOpenAI provider had this capability.

### Solution
- Added optional `baseUrl` field support for **all** LLM providers (OpenAI, Anthropic, Google, Ollama, etc.)
- Added "Use custom Base URL" checkbox toggle in settings - hidden by default, shown when user wants to customize
- Updated `helper.ts` to pass `baseUrl` to LangChain providers when configured
- Removed the separate "CustomOpenAI" provider option since all providers now support custom baseUrl

### Files Changed
- `pages/options/src/components/ModelSettings.tsx` - Added checkbox and conditional baseUrl input
- `chrome-extension/src/background/agent/helper.ts` - Pass baseUrl to all providers
- `packages/storage/lib/settings/types.ts` - Updated types
- `packages/i18n/locales/en/messages.json` - Added translation key

### Usage
1. Go to Settings > Model Settings
2. Select your provider (e.g., Anthropic)
3. Check "Use custom Base URL"
4. Enter your custom endpoint (e.g., `http://your-proxy.com/v1/messages`)

---

## Feature 2: Fix Done Action Response Display

### Problem
When Navigator calls the `done` action with a response message, the UI was only showing "done" instead of the actual response text.

**Expected:** User sees the AI's response message (e.g., "Hello! The page is empty...")
**Actual:** User only sees "done"

### Root Cause
In `SidePanel.tsx`, `ACT_OK` events were skipped by default (only shown during replay mode). The `done` action emits:
- `ACT_START` with content = "done"
- `ACT_OK` with content = actual response text

Since `ACT_OK` was skipped, users only saw "done".

### Solution
- Track the last action name using React state
- When `ACT_OK` is received, check if `lastActionName === 'done'`
- If so, display the `ACT_OK` content (the actual response)

### Files Changed
- `pages/side-panel/src/SidePanel.tsx` - Added lastActionName state and conditional display logic

---

## Testing

- Tested custom baseUrl with proxy server for Anthropic
- Verified done action now displays response text correctly
- Confirmed existing functionality (replay, other actions) works as expected