### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Looking for a powerful AI browser agent without the $200/month price tag of Open
 - **Flexible LLM Options** - Connect to your preferred LLM providers with the freedom to choose different models for different agents.
 - **Fully Open Source** - Complete transparency in how your browser is automated. No black boxes or hidden processes.
 
-> **Note:** We currently support OpenAI, Anthropic, Gemini, Ollama, Groq, Cerebras, Llama and custom OpenAI-Compatible providers, more providers will be supported.
+> **Note:** We currently support OpenAI, Anthropic, Gemini, Ollama, Groq, Cerebras, Llama, MiniMax and custom OpenAI-Compatible providers, more providers will be supported.
 
 
 ## 📊 Key Features

--- a/chrome-extension/src/background/agent/__tests__/minimax-provider.test.ts
+++ b/chrome-extension/src/background/agent/__tests__/minimax-provider.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ProviderTypeEnum, llmProviderModelNames, llmProviderParameters, AgentNameEnum } from '@extension/storage';
+import {
+  getProviderTypeByProviderId,
+  getDefaultDisplayNameFromProviderId,
+  getDefaultProviderConfig,
+  getDefaultAgentModelParams,
+} from '@extension/storage/lib/settings/llmProviders';
+
+// Mock ChatOpenAI to capture constructor args
+const mockChatOpenAI = vi.fn();
+vi.mock('@langchain/openai', () => ({
+  ChatOpenAI: mockChatOpenAI,
+  AzureChatOpenAI: vi.fn(),
+}));
+vi.mock('@langchain/anthropic', () => ({ ChatAnthropic: vi.fn() }));
+vi.mock('@langchain/google-genai', () => ({ ChatGoogleGenerativeAI: vi.fn() }));
+vi.mock('@langchain/xai', () => ({ ChatXAI: vi.fn() }));
+vi.mock('@langchain/groq', () => ({ ChatGroq: vi.fn() }));
+vi.mock('@langchain/cerebras', () => ({ ChatCerebras: vi.fn() }));
+vi.mock('@langchain/ollama', () => ({ ChatOllama: vi.fn() }));
+vi.mock('@langchain/deepseek', () => ({ ChatDeepSeek: vi.fn() }));
+
+describe('MiniMax Provider - Type Registration', () => {
+  it('should have MiniMax in ProviderTypeEnum', () => {
+    expect(ProviderTypeEnum.MiniMax).toBe('minimax');
+  });
+
+  it('should have MiniMax models defined', () => {
+    const models = llmProviderModelNames[ProviderTypeEnum.MiniMax];
+    expect(models).toBeDefined();
+    expect(models).toContain('MiniMax-M2.5');
+    expect(models).toContain('MiniMax-M2.5-highspeed');
+    expect(models).toHaveLength(2);
+  });
+
+  it('should have MiniMax parameters for Planner agent', () => {
+    const params = llmProviderParameters[ProviderTypeEnum.MiniMax];
+    expect(params).toBeDefined();
+    expect(params[AgentNameEnum.Planner]).toBeDefined();
+    expect(params[AgentNameEnum.Planner].temperature).toBe(0.7);
+    expect(params[AgentNameEnum.Planner].topP).toBe(0.9);
+  });
+
+  it('should have MiniMax parameters for Navigator agent', () => {
+    const params = llmProviderParameters[ProviderTypeEnum.MiniMax];
+    expect(params[AgentNameEnum.Navigator]).toBeDefined();
+    expect(params[AgentNameEnum.Navigator].temperature).toBe(0.3);
+    expect(params[AgentNameEnum.Navigator].topP).toBe(0.85);
+  });
+
+  it('should have MiniMax parameters with temperature > 0', () => {
+    const params = llmProviderParameters[ProviderTypeEnum.MiniMax];
+    // MiniMax requires temperature in (0, 1], verify defaults are valid
+    expect(params[AgentNameEnum.Planner].temperature).toBeGreaterThan(0);
+    expect(params[AgentNameEnum.Planner].temperature).toBeLessThanOrEqual(1);
+    expect(params[AgentNameEnum.Navigator].temperature).toBeGreaterThan(0);
+    expect(params[AgentNameEnum.Navigator].temperature).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('MiniMax Provider - Configuration', () => {
+  it('should resolve provider type correctly', () => {
+    expect(getProviderTypeByProviderId('minimax')).toBe(ProviderTypeEnum.MiniMax);
+  });
+
+  it('should return display name "MiniMax"', () => {
+    expect(getDefaultDisplayNameFromProviderId('minimax')).toBe('MiniMax');
+  });
+
+  it('should return default config with correct baseUrl', () => {
+    const config = getDefaultProviderConfig('minimax');
+    expect(config.baseUrl).toBe('https://api.minimax.io/v1');
+    expect(config.type).toBe(ProviderTypeEnum.MiniMax);
+    expect(config.name).toBe('MiniMax');
+    expect(config.apiKey).toBe('');
+  });
+
+  it('should include MiniMax models in default config', () => {
+    const config = getDefaultProviderConfig('minimax');
+    expect(config.modelNames).toBeDefined();
+    expect(config.modelNames).toContain('MiniMax-M2.5');
+    expect(config.modelNames).toContain('MiniMax-M2.5-highspeed');
+  });
+
+  it('should return correct default agent model params', () => {
+    const plannerParams = getDefaultAgentModelParams('minimax', AgentNameEnum.Planner);
+    expect(plannerParams.temperature).toBe(0.7);
+    expect(plannerParams.topP).toBe(0.9);
+
+    const navigatorParams = getDefaultAgentModelParams('minimax', AgentNameEnum.Navigator);
+    expect(navigatorParams.temperature).toBe(0.3);
+    expect(navigatorParams.topP).toBe(0.85);
+  });
+});
+
+describe('MiniMax Provider - createChatModel', () => {
+  it('should create ChatOpenAI instance for MiniMax provider', async () => {
+    // Dynamic import after mocks are set up
+    const { createChatModel } = await import('../helper');
+
+    const providerConfig = {
+      apiKey: 'test-minimax-key',
+      baseUrl: 'https://api.minimax.io/v1',
+      name: 'MiniMax',
+      type: ProviderTypeEnum.MiniMax,
+      modelNames: ['MiniMax-M2.5'],
+    };
+
+    const modelConfig = {
+      provider: ProviderTypeEnum.MiniMax,
+      modelName: 'MiniMax-M2.5',
+      parameters: { temperature: 0.7, topP: 0.9 },
+    };
+
+    createChatModel(providerConfig, modelConfig);
+
+    expect(mockChatOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'MiniMax-M2.5',
+        apiKey: 'test-minimax-key',
+        temperature: 0.7,
+        topP: 0.9,
+        configuration: expect.objectContaining({
+          baseURL: 'https://api.minimax.io/v1',
+        }),
+      }),
+    );
+  });
+
+  it('should clamp temperature=0 to 0.01 for MiniMax', async () => {
+    const { createChatModel } = await import('../helper');
+    mockChatOpenAI.mockClear();
+
+    const providerConfig = {
+      apiKey: 'test-key',
+      baseUrl: 'https://api.minimax.io/v1',
+      type: ProviderTypeEnum.MiniMax,
+    };
+
+    const modelConfig = {
+      provider: ProviderTypeEnum.MiniMax,
+      modelName: 'MiniMax-M2.5',
+      parameters: { temperature: 0, topP: 0.5 },
+    };
+
+    createChatModel(providerConfig, modelConfig);
+
+    expect(mockChatOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        temperature: 0.01,
+      }),
+    );
+  });
+
+  it('should keep valid temperature values unchanged for MiniMax', async () => {
+    const { createChatModel } = await import('../helper');
+    mockChatOpenAI.mockClear();
+
+    const providerConfig = {
+      apiKey: 'test-key',
+      baseUrl: 'https://api.minimax.io/v1',
+      type: ProviderTypeEnum.MiniMax,
+    };
+
+    const modelConfig = {
+      provider: ProviderTypeEnum.MiniMax,
+      modelName: 'MiniMax-M2.5-highspeed',
+      parameters: { temperature: 0.5, topP: 0.85 },
+    };
+
+    createChatModel(providerConfig, modelConfig);
+
+    expect(mockChatOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'MiniMax-M2.5-highspeed',
+        temperature: 0.5,
+      }),
+    );
+  });
+
+  it('should clamp temperature>1 to 1.0 for MiniMax', async () => {
+    const { createChatModel } = await import('../helper');
+    mockChatOpenAI.mockClear();
+
+    const providerConfig = {
+      apiKey: 'test-key',
+      baseUrl: 'https://api.minimax.io/v1',
+      type: ProviderTypeEnum.MiniMax,
+    };
+
+    const modelConfig = {
+      provider: ProviderTypeEnum.MiniMax,
+      modelName: 'MiniMax-M2.5',
+      parameters: { temperature: 1.5, topP: 0.9 },
+    };
+
+    createChatModel(providerConfig, modelConfig);
+
+    expect(mockChatOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        temperature: 1.0,
+      }),
+    );
+  });
+});
+
+describe('MiniMax Provider - Integration Smoke Tests', () => {
+  it('should not interfere with other providers in the enum', () => {
+    // Verify existing providers are unaffected
+    expect(ProviderTypeEnum.OpenAI).toBe('openai');
+    expect(ProviderTypeEnum.Anthropic).toBe('anthropic');
+    expect(ProviderTypeEnum.DeepSeek).toBe('deepseek');
+    expect(ProviderTypeEnum.Gemini).toBe('gemini');
+    expect(ProviderTypeEnum.CustomOpenAI).toBe('custom_openai');
+  });
+
+  it('should not affect CustomOpenAI as default provider type', () => {
+    expect(getProviderTypeByProviderId('unknown_provider')).toBe(ProviderTypeEnum.CustomOpenAI);
+  });
+
+  it('should have MiniMax between Llama and CustomOpenAI in getDefaultProviderConfig', () => {
+    // MiniMax should use the shared built-in provider config path
+    const minimaxConfig = getDefaultProviderConfig('minimax');
+    const llamaConfig = getDefaultProviderConfig('llama');
+    const customConfig = getDefaultProviderConfig('custom_anything');
+
+    // All should have apiKey
+    expect(minimaxConfig.apiKey).toBe('');
+    expect(llamaConfig.apiKey).toBe('');
+    expect(customConfig.apiKey).toBe('');
+
+    // MiniMax should have its own baseUrl
+    expect(minimaxConfig.baseUrl).toBe('https://api.minimax.io/v1');
+    expect(llamaConfig.baseUrl).toBe('https://api.llama.com/v1');
+    expect(customConfig.baseUrl).toBe('');
+  });
+
+  it('should handle MiniMax with default parameters when none specified', async () => {
+    const { createChatModel } = await import('../helper');
+    mockChatOpenAI.mockClear();
+
+    const providerConfig = {
+      apiKey: 'test-key',
+      baseUrl: 'https://api.minimax.io/v1',
+      type: ProviderTypeEnum.MiniMax,
+    };
+
+    const modelConfig = {
+      provider: ProviderTypeEnum.MiniMax,
+      modelName: 'MiniMax-M2.5',
+      // No parameters - should use defaults
+    };
+
+    createChatModel(providerConfig, modelConfig);
+
+    expect(mockChatOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        // Default temperature from createOpenAIChatModel is 0.1, clamped by MiniMax case
+        temperature: 0.1,
+      }),
+    );
+  });
+});

--- a/chrome-extension/src/background/agent/__tests__/minimax-provider.test.ts
+++ b/chrome-extension/src/background/agent/__tests__/minimax-provider.test.ts
@@ -29,17 +29,17 @@ describe('MiniMax Provider - Type Registration', () => {
   it('should have MiniMax models defined', () => {
     const models = llmProviderModelNames[ProviderTypeEnum.MiniMax];
     expect(models).toBeDefined();
+    expect(models).toContain('MiniMax-M3');
     expect(models).toContain('MiniMax-M2.7');
     expect(models).toContain('MiniMax-M2.7-highspeed');
-    expect(models).toContain('MiniMax-M2.5');
-    expect(models).toContain('MiniMax-M2.5-highspeed');
-    expect(models).toHaveLength(4);
+    expect(models).toHaveLength(3);
   });
 
-  it('should have MiniMax-M2.7 as the first (default) model', () => {
+  it('should have MiniMax-M3 as the first (default) model', () => {
     const models = llmProviderModelNames[ProviderTypeEnum.MiniMax];
-    expect(models[0]).toBe('MiniMax-M2.7');
-    expect(models[1]).toBe('MiniMax-M2.7-highspeed');
+    expect(models[0]).toBe('MiniMax-M3');
+    expect(models[1]).toBe('MiniMax-M2.7');
+    expect(models[2]).toBe('MiniMax-M2.7-highspeed');
   });
 
   it('should have MiniMax parameters for Planner agent', () => {
@@ -87,10 +87,9 @@ describe('MiniMax Provider - Configuration', () => {
   it('should include MiniMax models in default config', () => {
     const config = getDefaultProviderConfig('minimax');
     expect(config.modelNames).toBeDefined();
+    expect(config.modelNames).toContain('MiniMax-M3');
     expect(config.modelNames).toContain('MiniMax-M2.7');
     expect(config.modelNames).toContain('MiniMax-M2.7-highspeed');
-    expect(config.modelNames).toContain('MiniMax-M2.5');
-    expect(config.modelNames).toContain('MiniMax-M2.5-highspeed');
   });
 
   it('should return correct default agent model params', () => {
@@ -114,12 +113,12 @@ describe('MiniMax Provider - createChatModel', () => {
       baseUrl: 'https://api.minimax.io/v1',
       name: 'MiniMax',
       type: ProviderTypeEnum.MiniMax,
-      modelNames: ['MiniMax-M2.7'],
+      modelNames: ['MiniMax-M3'],
     };
 
     const modelConfig = {
       provider: ProviderTypeEnum.MiniMax,
-      modelName: 'MiniMax-M2.7',
+      modelName: 'MiniMax-M3',
       parameters: { temperature: 0.7, topP: 0.9 },
     };
 
@@ -127,7 +126,7 @@ describe('MiniMax Provider - createChatModel', () => {
 
     expect(mockChatOpenAI).toHaveBeenCalledWith(
       expect.objectContaining({
-        model: 'MiniMax-M2.7',
+        model: 'MiniMax-M3',
         apiKey: 'test-minimax-key',
         temperature: 0.7,
         topP: 0.9,
@@ -258,7 +257,7 @@ describe('MiniMax Provider - Integration Smoke Tests', () => {
 
     const modelConfig = {
       provider: ProviderTypeEnum.MiniMax,
-      modelName: 'MiniMax-M2.7',
+      modelName: 'MiniMax-M3',
       // No parameters - should use defaults
     };
 

--- a/chrome-extension/src/background/agent/__tests__/minimax-provider.test.ts
+++ b/chrome-extension/src/background/agent/__tests__/minimax-provider.test.ts
@@ -29,9 +29,17 @@ describe('MiniMax Provider - Type Registration', () => {
   it('should have MiniMax models defined', () => {
     const models = llmProviderModelNames[ProviderTypeEnum.MiniMax];
     expect(models).toBeDefined();
+    expect(models).toContain('MiniMax-M2.7');
+    expect(models).toContain('MiniMax-M2.7-highspeed');
     expect(models).toContain('MiniMax-M2.5');
     expect(models).toContain('MiniMax-M2.5-highspeed');
-    expect(models).toHaveLength(2);
+    expect(models).toHaveLength(4);
+  });
+
+  it('should have MiniMax-M2.7 as the first (default) model', () => {
+    const models = llmProviderModelNames[ProviderTypeEnum.MiniMax];
+    expect(models[0]).toBe('MiniMax-M2.7');
+    expect(models[1]).toBe('MiniMax-M2.7-highspeed');
   });
 
   it('should have MiniMax parameters for Planner agent', () => {
@@ -79,6 +87,8 @@ describe('MiniMax Provider - Configuration', () => {
   it('should include MiniMax models in default config', () => {
     const config = getDefaultProviderConfig('minimax');
     expect(config.modelNames).toBeDefined();
+    expect(config.modelNames).toContain('MiniMax-M2.7');
+    expect(config.modelNames).toContain('MiniMax-M2.7-highspeed');
     expect(config.modelNames).toContain('MiniMax-M2.5');
     expect(config.modelNames).toContain('MiniMax-M2.5-highspeed');
   });
@@ -104,12 +114,12 @@ describe('MiniMax Provider - createChatModel', () => {
       baseUrl: 'https://api.minimax.io/v1',
       name: 'MiniMax',
       type: ProviderTypeEnum.MiniMax,
-      modelNames: ['MiniMax-M2.5'],
+      modelNames: ['MiniMax-M2.7'],
     };
 
     const modelConfig = {
       provider: ProviderTypeEnum.MiniMax,
-      modelName: 'MiniMax-M2.5',
+      modelName: 'MiniMax-M2.7',
       parameters: { temperature: 0.7, topP: 0.9 },
     };
 
@@ -117,7 +127,7 @@ describe('MiniMax Provider - createChatModel', () => {
 
     expect(mockChatOpenAI).toHaveBeenCalledWith(
       expect.objectContaining({
-        model: 'MiniMax-M2.5',
+        model: 'MiniMax-M2.7',
         apiKey: 'test-minimax-key',
         temperature: 0.7,
         topP: 0.9,
@@ -140,7 +150,7 @@ describe('MiniMax Provider - createChatModel', () => {
 
     const modelConfig = {
       provider: ProviderTypeEnum.MiniMax,
-      modelName: 'MiniMax-M2.5',
+      modelName: 'MiniMax-M2.7',
       parameters: { temperature: 0, topP: 0.5 },
     };
 
@@ -165,7 +175,7 @@ describe('MiniMax Provider - createChatModel', () => {
 
     const modelConfig = {
       provider: ProviderTypeEnum.MiniMax,
-      modelName: 'MiniMax-M2.5-highspeed',
+      modelName: 'MiniMax-M2.7-highspeed',
       parameters: { temperature: 0.5, topP: 0.85 },
     };
 
@@ -173,7 +183,7 @@ describe('MiniMax Provider - createChatModel', () => {
 
     expect(mockChatOpenAI).toHaveBeenCalledWith(
       expect.objectContaining({
-        model: 'MiniMax-M2.5-highspeed',
+        model: 'MiniMax-M2.7-highspeed',
         temperature: 0.5,
       }),
     );
@@ -191,7 +201,7 @@ describe('MiniMax Provider - createChatModel', () => {
 
     const modelConfig = {
       provider: ProviderTypeEnum.MiniMax,
-      modelName: 'MiniMax-M2.5',
+      modelName: 'MiniMax-M2.7',
       parameters: { temperature: 1.5, topP: 0.9 },
     };
 
@@ -248,7 +258,7 @@ describe('MiniMax Provider - Integration Smoke Tests', () => {
 
     const modelConfig = {
       provider: ProviderTypeEnum.MiniMax,
-      modelName: 'MiniMax-M2.5',
+      modelName: 'MiniMax-M2.7',
       // No parameters - should use defaults
     };
 

--- a/chrome-extension/src/background/agent/helper.ts
+++ b/chrome-extension/src/background/agent/helper.ts
@@ -356,6 +356,16 @@ export function createChatModel(providerConfig: ProviderConfig, modelConfig: Mod
         },
       });
     }
+    case ProviderTypeEnum.MiniMax: {
+      // MiniMax is OpenAI-compatible but requires temperature in (0, 1]
+      const miniMaxModelConfig = { ...modelConfig };
+      const miniMaxTemp = (modelConfig.parameters?.temperature ?? 0.1) as number;
+      miniMaxModelConfig.parameters = {
+        ...modelConfig.parameters,
+        temperature: Math.max(0.01, Math.min(miniMaxTemp, 1.0)),
+      };
+      return createOpenAIChatModel(providerConfig, miniMaxModelConfig, undefined);
+    }
     case ProviderTypeEnum.Llama: {
       // Llama API has a different response format, use custom ChatLlama class
       const args: {

--- a/packages/storage/lib/settings/llmProviders.ts
+++ b/packages/storage/lib/settings/llmProviders.ts
@@ -67,6 +67,7 @@ export function getProviderTypeByProviderId(providerId: string): ProviderTypeEnu
     case ProviderTypeEnum.OpenRouter:
     case ProviderTypeEnum.Groq:
     case ProviderTypeEnum.Cerebras:
+    case ProviderTypeEnum.MiniMax:
       return providerId;
     default:
       return ProviderTypeEnum.CustomOpenAI;
@@ -99,6 +100,8 @@ export function getDefaultDisplayNameFromProviderId(providerId: string): string 
       return 'Cerebras';
     case ProviderTypeEnum.Llama:
       return 'Llama';
+    case ProviderTypeEnum.MiniMax:
+      return 'MiniMax';
     default:
       return providerId; // Use the provider id as display name for custom providers by default
   }
@@ -116,6 +119,7 @@ export function getDefaultProviderConfig(providerId: string): ProviderConfig {
     case ProviderTypeEnum.Groq: // Groq uses modelNames
     case ProviderTypeEnum.Cerebras: // Cerebras uses modelNames
     case ProviderTypeEnum.Llama: // Llama uses modelNames
+    case ProviderTypeEnum.MiniMax: // MiniMax uses modelNames
       return {
         apiKey: '',
         name: getDefaultDisplayNameFromProviderId(providerId),
@@ -125,7 +129,9 @@ export function getDefaultProviderConfig(providerId: string): ProviderConfig {
             ? 'https://openrouter.ai/api/v1'
             : providerId === ProviderTypeEnum.Llama
               ? 'https://api.llama.com/v1'
-              : undefined,
+              : providerId === ProviderTypeEnum.MiniMax
+                ? 'https://api.minimax.io/v1'
+                : undefined,
         modelNames: [...(llmProviderModelNames[providerId] || [])],
         createdAt: Date.now(),
       };

--- a/packages/storage/lib/settings/types.ts
+++ b/packages/storage/lib/settings/types.ts
@@ -50,7 +50,7 @@ export const llmProviderModelNames = {
     'Llama-4-Maverick-17B-128E-Instruct-FP8',
     'Llama-4-Scout-17B-16E-Instruct-FP8',
   ],
-  [ProviderTypeEnum.MiniMax]: ['MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
+  [ProviderTypeEnum.MiniMax]: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
   // Custom OpenAI providers don't have predefined models as they are user-defined
 };
 

--- a/packages/storage/lib/settings/types.ts
+++ b/packages/storage/lib/settings/types.ts
@@ -50,7 +50,7 @@ export const llmProviderModelNames = {
     'Llama-4-Maverick-17B-128E-Instruct-FP8',
     'Llama-4-Scout-17B-16E-Instruct-FP8',
   ],
-  [ProviderTypeEnum.MiniMax]: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
+  [ProviderTypeEnum.MiniMax]: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
   // Custom OpenAI providers don't have predefined models as they are user-defined
 };
 

--- a/packages/storage/lib/settings/types.ts
+++ b/packages/storage/lib/settings/types.ts
@@ -19,6 +19,7 @@ export enum ProviderTypeEnum {
   Groq = 'groq',
   Cerebras = 'cerebras',
   Llama = 'llama',
+  MiniMax = 'minimax',
   CustomOpenAI = 'custom_openai',
 }
 
@@ -49,6 +50,7 @@ export const llmProviderModelNames = {
     'Llama-4-Maverick-17B-128E-Instruct-FP8',
     'Llama-4-Scout-17B-16E-Instruct-FP8',
   ],
+  [ProviderTypeEnum.MiniMax]: ['MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
   // Custom OpenAI providers don't have predefined models as they are user-defined
 };
 
@@ -145,6 +147,16 @@ export const llmProviderParameters = {
     },
   },
   [ProviderTypeEnum.Llama]: {
+    [AgentNameEnum.Planner]: {
+      temperature: 0.7,
+      topP: 0.9,
+    },
+    [AgentNameEnum.Navigator]: {
+      temperature: 0.3,
+      topP: 0.85,
+    },
+  },
+  [ProviderTypeEnum.MiniMax]: {
     [AgentNameEnum.Planner]: {
       temperature: 0.7,
       topP: 0.9,


### PR DESCRIPTION
## Summary

Upgrade the MiniMax provider in Nanobrowser to use **MiniMax-M3** as the default model. M3 brings a 512K context window, up to 128K output, and image input support, while keeping M2.7 / M2.7-highspeed available as alternatives.

### Changes

- **Model List**: `llmProviderModelNames[ProviderTypeEnum.MiniMax]` is now `['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed']`
- **Default**: `MiniMax-M3` is the first model in the list, so newly created MiniMax provider configs default to M3
- **Removed**: `MiniMax-M2.5` and `MiniMax-M2.5-highspeed` (older generation)
- **Tests**: Updated unit tests to assert M3 is the first (default) model and to exercise M3 in `createChatModel` coverage

### Why M3?

- 512K context window (up from 204K on M2.5/M2.7)
- Up to 128K maximum output tokens
- Image input support
- Same OpenAI-compatible base URL (`https://api.minimax.io/v1`)

### Temperature Handling (unchanged)

MiniMax still requires temperature in `(0, 1]`; the existing `MiniMax` case in `createChatModel()` clamps to `[0.01, 1.0]`.

## Test Plan

- [x] All 19 MiniMax unit tests pass (added M3 assertions)
- [x] All 14 existing guardrails tests continue to pass (33/33 total)
- [x] TypeScript type-check passes for `@extension/storage` package
- [x] Full production build succeeds