### PR TITLE
feat: suggested prompts, manual theme toggle, and styling refinements

### DIFF
--- a/pages/options/src/Options.css
+++ b/pages/options/src/Options.css
@@ -4,6 +4,12 @@
   height: 100vh;
 }
 
+.options-shell {
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
+}
+
 .App-logo {
   height: 40vmin;
   pointer-events: none;
@@ -25,22 +31,36 @@ code {
   padding: 0.2rem 0.5rem;
 }
 
-/* Dark mode support */
-@media (prefers-color-scheme: dark) {
-  code {
-    background: rgba(30, 58, 138, 0.4);
-    color: #7dd3fc;
-  }
-  
-  .dark-mode-text {
-    color: #e2e8f0 !important; /* slate-200 */
-  }
-  
-  .dark-mode-bg {
-    background-color: #1e293b !important; /* slate-800 */
-  }
-  
-  .dark-mode-border {
-    border-color: #475569 !important; /* slate-600 */
-  }
+.light code {
+  background: rgba(148, 163, 184, 0.32);
+  color: #0f172a;
+}
+
+.dark code {
+  background: rgba(30, 58, 138, 0.4);
+  color: #7dd3fc;
+}
+
+.dark .dark-mode-text {
+  color: #e2e8f0 !important;
+}
+
+.light .dark-mode-text {
+  color: #111827 !important;
+}
+
+.dark .dark-mode-bg {
+  background-color: #1e293b !important;
+}
+
+.light .dark-mode-bg {
+  background-color: #ffffff !important;
+}
+
+.dark .dark-mode-border {
+  border-color: #475569 !important;
+}
+
+.light .dark-mode-border {
+  border-color: rgba(148, 163, 184, 0.4) !important;
 }

--- a/pages/options/src/Options.tsx
+++ b/pages/options/src/Options.tsx
@@ -3,7 +3,7 @@ import '@src/Options.css';
 import { Button } from '@extension/ui';
 import { withErrorBoundary, withSuspense } from '@extension/shared';
 import { t } from '@extension/i18n';
-import { FiSettings, FiCpu, FiShield, FiTrendingUp, FiHelpCircle } from 'react-icons/fi';
+import { FiSettings, FiCpu, FiShield, FiTrendingUp, FiHelpCircle, FiSun, FiMoon } from 'react-icons/fi';
 import { GeneralSettings } from './components/GeneralSettings';
 import { ModelSettings } from './components/ModelSettings';
 import { FirewallSettings } from './components/FirewallSettings';
@@ -19,22 +19,39 @@ const TABS: { id: TabTypes; icon: React.ComponentType<{ className?: string }>; l
   { id: 'help', icon: FiHelpCircle, label: t('options_tabs_help') },
 ];
 
+const THEME_STORAGE_KEY = 'nanobrowser:theme';
+
 const Options = () => {
   const [activeTab, setActiveTab] = useState<TabTypes>('models');
   const [isDarkMode, setIsDarkMode] = useState(false);
 
-  // Check for dark mode preference
   useEffect(() => {
     const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-    setIsDarkMode(darkModeMediaQuery.matches);
+    const storedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+
+    if (storedTheme === 'dark' || storedTheme === 'light') {
+      setIsDarkMode(storedTheme === 'dark');
+    } else {
+      setIsDarkMode(darkModeMediaQuery.matches);
+    }
 
     const handleChange = (e: MediaQueryListEvent) => {
-      setIsDarkMode(e.matches);
+      if (!localStorage.getItem(THEME_STORAGE_KEY)) {
+        setIsDarkMode(e.matches);
+      }
     };
 
     darkModeMediaQuery.addEventListener('change', handleChange);
     return () => darkModeMediaQuery.removeEventListener('change', handleChange);
   }, []);
+
+  const toggleDarkMode = () => {
+    setIsDarkMode(prev => {
+      const next = !prev;
+      localStorage.setItem(THEME_STORAGE_KEY, next ? 'dark' : 'light');
+      return next;
+    });
+  };
 
   const handleTabClick = (tabId: TabTypes) => {
     if (tabId === 'help') {
@@ -61,7 +78,7 @@ const Options = () => {
 
   return (
     <div
-      className={`flex min-h-screen min-w-[768px] ${isDarkMode ? 'bg-slate-900' : "bg-[url('/bg.jpg')] bg-cover bg-center"} ${isDarkMode ? 'text-gray-200' : 'text-gray-900'}`}>
+      className={`options-shell ${isDarkMode ? 'dark bg-slate-900 text-gray-200' : 'light bg-[url(\'/bg.jpg\')] bg-cover bg-center text-gray-900'} flex min-h-screen min-w-[768px]`}>
       {/* Vertical Navigation Bar */}
       <nav
         className={`w-48 border-r ${isDarkMode ? 'border-slate-700 bg-slate-800/80' : 'border-white/20 bg-[#0EA5E9]/10'} backdrop-blur-sm`}>
@@ -80,12 +97,32 @@ const Options = () => {
                         ? `${isDarkMode ? 'bg-slate-700/70 text-gray-300 hover:text-white' : 'bg-[#0EA5E9]/15 font-medium text-gray-700 hover:text-white'} backdrop-blur-sm`
                         : `${isDarkMode ? 'bg-sky-800/50' : ''} text-white backdrop-blur-sm`
                     }`}>
-                  <item.icon className="h-4 w-4" />
+                  <item.icon className="size-4" />
                   <span>{item.label}</span>
                 </Button>
               </li>
             ))}
           </ul>
+
+          <div
+            className={`mt-6 flex items-center justify-between rounded-xl border px-3 py-2 backdrop-blur-sm ${
+              isDarkMode ? 'border-slate-700 bg-slate-900/60' : 'border-white/10 bg-white/10'
+            }`}>
+            <span className={`text-xs font-medium ${isDarkMode ? 'text-slate-300' : 'text-gray-700'}`}>
+              {isDarkMode ? 'Dark mode' : 'Light mode'}
+            </span>
+            <button
+              type="button"
+              onClick={toggleDarkMode}
+              aria-label={isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+              className={`flex size-8 items-center justify-center rounded-full transition-all hover:scale-105 active:scale-95 ${
+                isDarkMode
+                  ? 'bg-slate-700 text-amber-300 hover:bg-slate-600'
+                  : 'bg-white/80 text-slate-700 hover:bg-white'
+              }`}>
+              {isDarkMode ? <FiSun className="size-4" /> : <FiMoon className="size-4" />}
+            </button>
+          </div>
         </div>
       </nav>
 

--- a/pages/side-panel/src/SidePanel.tsx
+++ b/pages/side-panel/src/SidePanel.tsx
@@ -11,6 +11,7 @@ import MessageList from './components/MessageList';
 import ChatInput from './components/ChatInput';
 import ChatHistoryList from './components/ChatHistoryList';
 import BookmarkList from './components/BookmarkList';
+import SuggestedPrompts from './components/SuggestedPrompts';
 import { EventType, type AgentEvent, ExecutionState } from './types/event';
 import './SidePanel.css';
 
@@ -762,6 +763,12 @@ const SidePanel = () => {
     }
   };
 
+  const handleSuggestedPromptSelect = (content: string) => {
+    if (setInputTextRef.current) {
+      setInputTextRef.current(content);
+    }
+  };
+
   const handleBookmarkUpdateTitle = async (id: number, title: string) => {
     try {
       await favoritesStorage.updatePromptTitle(id, title);
@@ -1002,7 +1009,7 @@ const SidePanel = () => {
   return (
     <div>
       <div
-        className={`flex h-screen flex-col ${isDarkMode ? 'bg-slate-900' : "bg-[url('/bg.jpg')] bg-cover bg-no-repeat"} overflow-hidden border ${isDarkMode ? 'border-sky-800' : 'border-[rgb(186,230,253)]'} rounded-2xl`}>
+        className={`flex h-screen flex-col ${isDarkMode ? 'bg-slate-900' : 'bg-gradient-to-b from-sky-50 via-white to-white'} overflow-hidden border ${isDarkMode ? 'border-sky-800' : 'border-sky-100'} rounded-2xl`}>
         <header className="header relative">
           <div className="header-logo">
             {showHistory ? (
@@ -1123,6 +1130,22 @@ const SidePanel = () => {
             {/* Show normal chat interface when models are configured */}
             {hasConfiguredModels === true && (
               <>
+                {isHistoricalSession && (
+                  <div
+                    className={`mx-2 mt-2 flex items-center justify-between gap-3 rounded-xl border px-3 py-2 text-xs ${
+                      isDarkMode
+                        ? 'border-slate-700 bg-slate-800/80 text-slate-300'
+                        : 'border-sky-100 bg-white/80 text-slate-600'
+                    }`}>
+                    <span>Viewing past session - read only</span>
+                    <button
+                      type="button"
+                      onClick={handleNewChat}
+                      className="shrink-0 font-semibold text-sky-500 hover:text-sky-400 hover:underline">
+                      New chat
+                    </button>
+                  </div>
+                )}
                 {messages.length === 0 && (
                   <>
                     <div
@@ -1144,6 +1167,7 @@ const SidePanel = () => {
                       />
                     </div>
                     <div className="flex-1 overflow-y-auto">
+                      <SuggestedPrompts onSelect={handleSuggestedPromptSelect} isDarkMode={isDarkMode} />
                       <BookmarkList
                         bookmarks={favoritePrompts}
                         onBookmarkSelect={handleBookmarkSelect}

--- a/pages/side-panel/src/components/SuggestedPrompts.tsx
+++ b/pages/side-panel/src/components/SuggestedPrompts.tsx
@@ -1,0 +1,79 @@
+import { LuSparkles } from 'react-icons/lu';
+
+interface SuggestedPrompt {
+  title: string;
+  description: string;
+  prompt: string;
+  icon: string;
+}
+
+interface SuggestedPromptsProps {
+  onSelect: (prompt: string) => void;
+  isDarkMode?: boolean;
+}
+
+const SUGGESTIONS: SuggestedPrompt[] = [
+  {
+    title: 'Research',
+    description: 'Summarize the latest homepage headlines from a site.',
+    prompt: 'Go to TechCrunch and extract the top 10 headlines from the last 24 hours.',
+    icon: '🔎',
+  },
+  {
+    title: 'GitHub',
+    description: 'Find strong repos in a language or topic.',
+    prompt: 'Look for the trending Python repositories on GitHub with the most stars.',
+    icon: '💻',
+  },
+  {
+    title: 'Shopping',
+    description: 'Compare products with clear constraints.',
+    prompt:
+      'Find a portable Bluetooth speaker on Amazon under $50 with water resistance and at least 10 hours of battery life.',
+    icon: '🛍️',
+  },
+  {
+    title: 'Planning',
+    description: 'Collect options and make a recommendation.',
+    prompt: 'Compare three coworking spaces in Bangalore with pricing, ratings, and amenities.',
+    icon: '🧭',
+  },
+];
+
+const SuggestedPrompts = ({ onSelect, isDarkMode = false }: SuggestedPromptsProps) => {
+  return (
+    <section className="py-2" aria-label="Suggested prompts">
+      <div className="mb-3 flex items-center gap-2 px-2">
+        <LuSparkles className={isDarkMode ? 'text-sky-300' : 'text-sky-500'} size={14} />
+        <h3 className={`text-xs font-semibold uppercase tracking-[0.18em] ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+          Try these
+        </h3>
+      </div>
+      <div className="flex gap-3 overflow-x-auto px-2 pb-1">
+        {SUGGESTIONS.map(suggestion => (
+          <button
+            key={suggestion.title}
+            type="button"
+            onClick={() => onSelect(suggestion.prompt)}
+            className={`flex w-40 shrink-0 flex-col items-start gap-1 rounded-2xl border p-3 text-left shadow-sm transition-transform hover:scale-[1.02] active:scale-95 ${
+              isDarkMode
+                ? 'border-slate-700 bg-slate-800/80 hover:bg-slate-800'
+                : 'border-sky-100 bg-white/85 hover:bg-white'
+            }`}>
+            <span className="text-lg" aria-hidden="true">
+              {suggestion.icon}
+            </span>
+            <span className={`text-xs font-semibold leading-tight ${isDarkMode ? 'text-slate-100' : 'text-slate-800'}`}>
+              {suggestion.title}
+            </span>
+            <span className={`text-[11px] leading-tight ${isDarkMode ? 'text-slate-400' : 'text-slate-500'}`}>
+              {suggestion.description}
+            </span>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default SuggestedPrompts;


### PR DESCRIPTION
Summary
This PR adds a suggested prompts feature to the side panel, refactors theme handling on the options page to support manual dark/light toggling, and cleans up styling across both panels for better visual consistency.

Motivation
The side panel had no onboarding cues for new users, making it unclear where to start. The options page relied on system media queries for theming, which made user-controlled preferences impossible. These changes address both gaps.

Changes
Suggested prompts (pages/side-panel/src/components/SuggestedPrompts.tsx)

New SuggestedPrompts component renders a curated list of clickable prompt suggestions in the side panel
Selecting a suggestion inserts it directly into the chat input
Theme handling (pages/options/src/Options.tsx, Options.css)

Replaced media-query-based theming with explicit .dark / .light CSS classes for easier maintenance
User preference is stored in localStorage and persists across sessions

Styling (pages/side-panel/src/SidePanel.tsx)

Background and border styles updated to stay consistent with the active theme across both the options page and side panel
Testing
Tested manually in both dark and light modes
Theme preference persists correctly after page reload
Suggested prompts insert into the chat input as expected
No regressions observed in existing side panel behavior
Happy to adjust based on feedback — let me know if anything needs more context or a different approach.