### PR TITLE
fix: add toString() to DOMElementNode for readable error messages

### DIFF
--- a/chrome-extension/src/background/browser/dom/views.ts
+++ b/chrome-extension/src/background/browser/dom/views.ts
@@ -181,6 +181,17 @@ export class DOMElementNode extends DOMBaseNode {
     this._hashPromise = undefined;
   }
 
+  toString(): string {
+    const tag = this.tagName ?? 'unknown';
+    if (this.highlightIndex !== null) {
+      return `<${tag}[index=${this.highlightIndex}]>`;
+    }
+    if (this.xpath) {
+      return `<${tag}[@${this.xpath}]>`;
+    }
+    return `<${tag}>`;
+  }
+
   getAllTextTillNextClickableElement(maxDepth = -1): string {
     const textParts: string[] = [];
 


### PR DESCRIPTION
Fixes #275

## Problem

Error messages throughout `page.ts` used template literals with `DOMElementNode` objects directly (e.g., `` `Element: ${elementNode} not found` ``), which produces the unhelpful string `[object Object]` since the class had no `toString()` method. Users reported seeing messages like:

```
Failed to input text into element: [object Object]. Error: Element: [object Object] not found
```

## Solution

Add a `toString()` method to `DOMElementNode` in `views.ts` that returns a human-readable description:

- `<input[index=5]>` — when `highlightIndex` is set
- `<div[@//div/input]>` — when only `xpath` is available  
- `<div>` — fallback with tag name only

This fixes all occurrences in `page.ts` where `elementNode` is interpolated into error strings (14 locations), without requiring changes to any of those call sites.

## Testing

Error messages now include meaningful element identifiers, e.g.:
```
Failed to input text into element: <input[index=3]>. Error: Element: <input[index=3]> not found
```